### PR TITLE
feat: add stop sequences support for both endpoints

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -639,8 +639,8 @@ class ChatStreamChunk(BaseModel):
 
 
 def resolve_stop_sequences(
-    stop: Optional[Union[str, list]],
-) -> Optional[list]:
+    stop: Optional[Union[str, List[str]]],
+) -> Optional[List[str]]:
     """Normalize stop sequences for the generation stopping criteria.
 
     The generation pipeline's ``add_eos_token_ids`` accepts strings
@@ -877,7 +877,7 @@ async def responses_endpoint(openai_request: OpenAIRequest):
         )
         generation_kwargs = build_generation_kwargs(openai_request, template_kwargs)
 
-        # Resolve stop sequences to token IDs
+        # Resolve stop sequences to strings for eos_tokens
         stop_seqs = resolve_stop_sequences(getattr(openai_request, "stop", None))
         if stop_seqs:
             generation_kwargs["eos_tokens"] = stop_seqs
@@ -1150,7 +1150,7 @@ async def chat_completions_endpoint(request: ChatRequest):
         )
         generation_kwargs = build_generation_kwargs(request, template_kwargs)
 
-        # Resolve stop sequences to token IDs
+        # Resolve stop sequences to strings for eos_tokens
         stop_seqs = resolve_stop_sequences(getattr(request, "stop", None))
         if stop_seqs:
             generation_kwargs["eos_tokens"] = stop_seqs

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -638,30 +638,26 @@ class ChatStreamChunk(BaseModel):
     usage: Optional[UsageStats]
 
 
-def resolve_stop_tokens(
+def resolve_stop_sequences(
     stop: Optional[Union[str, list]],
-    processor: Any,
-) -> Optional[set]:
-    """Convert stop string(s) to token IDs for the stopping criteria.
+) -> Optional[list]:
+    """Normalize stop sequences for the generation stopping criteria.
+
+    The generation pipeline's ``add_eos_token_ids`` accepts strings
+    and handles tokenization internally.
 
     Args:
         stop: A single stop string or list of stop strings, or None.
-        processor: The tokenizer/processor for encoding.
 
     Returns:
-        A set of token IDs, or None if no stop sequences provided.
+        A list of stop strings (max 4), or None.
     """
     if not stop:
         return None
-    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
     if isinstance(stop, str):
         stop = [stop]
-    token_ids = set()
-    for seq in stop[:4]:  # OpenAI limits to 4 stop sequences
-        ids = tokenizer.encode(seq, add_special_tokens=False)
-        if ids:
-            token_ids.add(ids[-1])  # Use last token as stop trigger
-    return token_ids if token_ids else None
+    sequences = [s for s in stop[:4] if isinstance(s, str) and s]
+    return sequences if sequences else None
 
 
 def build_generation_kwargs(
@@ -882,11 +878,9 @@ async def responses_endpoint(openai_request: OpenAIRequest):
         generation_kwargs = build_generation_kwargs(openai_request, template_kwargs)
 
         # Resolve stop sequences to token IDs
-        stop_tokens = resolve_stop_tokens(
-            getattr(openai_request, "stop", None), processor,
-        )
-        if stop_tokens:
-            generation_kwargs["eos_tokens"] = stop_tokens
+        stop_seqs = resolve_stop_sequences(getattr(openai_request, "stop", None))
+        if stop_seqs:
+            generation_kwargs["eos_tokens"] = stop_seqs
 
         generated_at = datetime.now().timestamp()
         response_id = f"resp_{uuid.uuid4().hex}"
@@ -1157,11 +1151,9 @@ async def chat_completions_endpoint(request: ChatRequest):
         generation_kwargs = build_generation_kwargs(request, template_kwargs)
 
         # Resolve stop sequences to token IDs
-        stop_tokens = resolve_stop_tokens(
-            getattr(request, "stop", None), processor,
-        )
-        if stop_tokens:
-            generation_kwargs["eos_tokens"] = stop_tokens
+        stop_seqs = resolve_stop_sequences(getattr(request, "stop", None))
+        if stop_seqs:
+            generation_kwargs["eos_tokens"] = stop_seqs
 
         if request.stream:
             # Streaming response

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -382,6 +382,10 @@ class OpenAIRequest(GenerationParams, TemplateParams):
     stream: bool = Field(
         False, description="Whether to stream the response chunk by chunk."
     )
+    stop: Optional[Union[str, List[str]]] = Field(
+        None,
+        description="Up to 4 sequences where the API will stop generating further tokens.",
+    )
 
     def generation_kwargs(self) -> dict[str, Any]:
         kwargs = self.dump_kwargs("max_output_tokens")
@@ -559,6 +563,10 @@ class VLMRequest(GenerationParams, TemplateParams):
         description="Maximum number of tokens to generate.",
     )
     seed: int = Field(DEFAULT_SEED, description="Seed for random generation.")
+    stop: Optional[Union[str, List[str]]] = Field(
+        None,
+        description="Up to 4 sequences where the API will stop generating further tokens.",
+    )
     resize_shape: Optional[ResizeShapeInput] = Field(
         None,
         description="Resize shape for the image. Provide one integer for a square resize or two integers for (height, width).",
@@ -628,6 +636,32 @@ class ChatStreamChunk(BaseModel):
     model: str
     choices: List[ChatStreamChoice]
     usage: Optional[UsageStats]
+
+
+def resolve_stop_tokens(
+    stop: Optional[Union[str, list]],
+    processor: Any,
+) -> Optional[set]:
+    """Convert stop string(s) to token IDs for the stopping criteria.
+
+    Args:
+        stop: A single stop string or list of stop strings, or None.
+        processor: The tokenizer/processor for encoding.
+
+    Returns:
+        A set of token IDs, or None if no stop sequences provided.
+    """
+    if not stop:
+        return None
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    if isinstance(stop, str):
+        stop = [stop]
+    token_ids = set()
+    for seq in stop[:4]:  # OpenAI limits to 4 stop sequences
+        ids = tokenizer.encode(seq, add_special_tokens=False)
+        if ids:
+            token_ids.add(ids[-1])  # Use last token as stop trigger
+    return token_ids if token_ids else None
 
 
 def build_generation_kwargs(
@@ -846,6 +880,13 @@ async def responses_endpoint(openai_request: OpenAIRequest):
             **template_kwargs,
         )
         generation_kwargs = build_generation_kwargs(openai_request, template_kwargs)
+
+        # Resolve stop sequences to token IDs
+        stop_tokens = resolve_stop_tokens(
+            getattr(openai_request, "stop", None), processor,
+        )
+        if stop_tokens:
+            generation_kwargs["eos_tokens"] = stop_tokens
 
         generated_at = datetime.now().timestamp()
         response_id = f"resp_{uuid.uuid4().hex}"
@@ -1114,6 +1155,13 @@ async def chat_completions_endpoint(request: ChatRequest):
             **template_kwargs,
         )
         generation_kwargs = build_generation_kwargs(request, template_kwargs)
+
+        # Resolve stop sequences to token IDs
+        stop_tokens = resolve_stop_tokens(
+            getattr(request, "stop", None), processor,
+        )
+        if stop_tokens:
+            generation_kwargs["eos_tokens"] = stop_tokens
 
         if request.stream:
             # Streaming response

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -130,3 +130,158 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     assert mock_generate.call_args.kwargs["repetition_penalty"] == 1.15
     assert mock_generate.call_args.kwargs["logit_bias"] == {12: -1.5}
     assert mock_generate.call_args.kwargs["resize_shape"] == (512, 512)
+
+
+# ---------------------------------------------------------------------------
+# Stop sequences tests
+# ---------------------------------------------------------------------------
+
+
+def test_chat_completions_stop_string_passed_as_eos_tokens(client):
+    """stop parameter should be resolved to eos_tokens in generate kwargs."""
+    model = SimpleNamespace()
+    processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            chat_template="",
+            encode=lambda s, add_special_tokens=False: [42],
+        ),
+    )
+    config = SimpleNamespace(model_type="test")
+    result = SimpleNamespace(
+        text="Hello",
+        prompt_tokens=5,
+        generation_tokens=1,
+        total_tokens=6,
+        prompt_tps=100.0,
+        generation_tps=50.0,
+        peak_memory=1.0,
+    )
+
+    with (
+        patch.object(server, "get_cached_model", return_value=(model, processor, config)),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result) as mock_gen,
+    ):
+        resp = client.post(
+            "/chat/completions",
+            json={
+                "model": "demo",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stop": ["\n\n", "</s>"],
+            },
+        )
+    assert resp.status_code == 200
+    assert "eos_tokens" in mock_gen.call_args.kwargs
+    assert isinstance(mock_gen.call_args.kwargs["eos_tokens"], set)
+    assert 42 in mock_gen.call_args.kwargs["eos_tokens"]
+
+
+def test_chat_completions_no_stop_no_eos_tokens(client):
+    """Without stop parameter, eos_tokens should not be in kwargs."""
+    model = SimpleNamespace()
+    processor = SimpleNamespace(tokenizer=SimpleNamespace(chat_template=""))
+    config = SimpleNamespace(model_type="test")
+    result = SimpleNamespace(
+        text="Hi",
+        prompt_tokens=5,
+        generation_tokens=1,
+        total_tokens=6,
+        prompt_tps=100.0,
+        generation_tps=50.0,
+        peak_memory=1.0,
+    )
+
+    with (
+        patch.object(server, "get_cached_model", return_value=(model, processor, config)),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result) as mock_gen,
+    ):
+        resp = client.post(
+            "/chat/completions",
+            json={"model": "demo", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    assert resp.status_code == 200
+    assert "eos_tokens" not in mock_gen.call_args.kwargs
+
+
+def test_responses_stop_string_passed_as_eos_tokens(client):
+    """stop parameter on /responses should also resolve to eos_tokens."""
+    model = SimpleNamespace()
+    processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            chat_template="",
+            encode=lambda s, add_special_tokens=False: [99],
+        ),
+    )
+    config = SimpleNamespace(model_type="test")
+    result = SimpleNamespace(
+        text="Hello",
+        prompt_tokens=5,
+        generation_tokens=1,
+        total_tokens=6,
+        prompt_tps=100.0,
+        generation_tps=50.0,
+        peak_memory=1.0,
+    )
+
+    with (
+        patch.object(server, "get_cached_model", return_value=(model, processor, config)),
+        patch.object(server, "apply_chat_template", return_value="prompt"),
+        patch.object(server, "generate", return_value=result) as mock_gen,
+    ):
+        resp = client.post(
+            "/responses",
+            json={"model": "demo", "input": "hi", "stop": "STOP"},
+        )
+    assert resp.status_code == 200
+    assert "eos_tokens" in mock_gen.call_args.kwargs
+    assert 99 in mock_gen.call_args.kwargs["eos_tokens"]
+
+
+def test_resolve_stop_tokens_single_string():
+    """resolve_stop_tokens should handle a single string."""
+    fake_processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(
+            encode=lambda s, add_special_tokens=False: [10, 20],
+        ),
+    )
+    result = server.resolve_stop_tokens("hello", fake_processor)
+    assert result == {20}  # Last token of encoded string
+
+
+def test_resolve_stop_tokens_list():
+    """resolve_stop_tokens should handle a list of strings."""
+    call_count = [0]
+    token_map = {0: [10], 1: [20, 30]}
+
+    def fake_encode(s, add_special_tokens=False):
+        idx = call_count[0]
+        call_count[0] += 1
+        return token_map.get(idx, [])
+
+    fake_processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(encode=fake_encode),
+    )
+    result = server.resolve_stop_tokens(["a", "b"], fake_processor)
+    assert 10 in result
+    assert 30 in result
+
+
+def test_resolve_stop_tokens_none():
+    """resolve_stop_tokens should return None for None input."""
+    assert server.resolve_stop_tokens(None, None) is None
+
+
+def test_resolve_stop_tokens_limits_to_four():
+    """resolve_stop_tokens should process at most 4 sequences."""
+    call_count = [0]
+
+    def fake_encode(s, add_special_tokens=False):
+        call_count[0] += 1
+        return [call_count[0]]
+
+    fake_processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(encode=fake_encode),
+    )
+    result = server.resolve_stop_tokens(["a", "b", "c", "d", "e", "f"], fake_processor)
+    assert len(result) == 4  # Only first 4 processed

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -137,14 +137,11 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
 # ---------------------------------------------------------------------------
 
 
-def test_chat_completions_stop_string_passed_as_eos_tokens(client):
-    """stop parameter should be resolved to eos_tokens in generate kwargs."""
+def test_chat_completions_stop_passed_as_eos_tokens(client):
+    """stop parameter should be forwarded as eos_tokens strings in generate kwargs."""
     model = SimpleNamespace()
     processor = SimpleNamespace(
-        tokenizer=SimpleNamespace(
-            chat_template="",
-            encode=lambda s, add_special_tokens=False: [42],
-        ),
+        tokenizer=SimpleNamespace(chat_template=""),
     )
     config = SimpleNamespace(model_type="test")
     result = SimpleNamespace(
@@ -203,14 +200,11 @@ def test_chat_completions_no_stop_no_eos_tokens(client):
     assert "eos_tokens" not in mock_gen.call_args.kwargs
 
 
-def test_responses_stop_string_passed_as_eos_tokens(client):
-    """stop parameter on /responses should also resolve to eos_tokens."""
+def test_responses_stop_passed_as_eos_tokens(client):
+    """stop parameter on /responses should also forward as eos_tokens strings."""
     model = SimpleNamespace()
     processor = SimpleNamespace(
-        tokenizer=SimpleNamespace(
-            chat_template="",
-            encode=lambda s, add_special_tokens=False: [99],
-        ),
+        tokenizer=SimpleNamespace(chat_template=""),
     )
     config = SimpleNamespace(model_type="test")
     result = SimpleNamespace(
@@ -238,29 +232,13 @@ def test_responses_stop_string_passed_as_eos_tokens(client):
 
 
 def test_resolve_stop_sequences_single_string():
-    """resolve_stop_sequences should handle a single string."""
-    fake_processor = SimpleNamespace(
-        tokenizer=SimpleNamespace(
-            encode=lambda s, add_special_tokens=False: [10, 20],
-        ),
-    )
+    """resolve_stop_sequences should wrap a single string in a list."""
     result = server.resolve_stop_sequences("hello")
     assert result == ["hello"]
 
 
 def test_resolve_stop_sequences_list():
-    """resolve_stop_sequences should handle a list of strings."""
-    call_count = [0]
-    token_map = {0: [10], 1: [20, 30]}
-
-    def fake_encode(s, add_special_tokens=False):
-        idx = call_count[0]
-        call_count[0] += 1
-        return token_map.get(idx, [])
-
-    fake_processor = SimpleNamespace(
-        tokenizer=SimpleNamespace(encode=fake_encode),
-    )
+    """resolve_stop_sequences should pass through a list of strings."""
     result = server.resolve_stop_sequences(["a", "b"])
     assert result == ["a", "b"]
 
@@ -271,15 +249,6 @@ def test_resolve_stop_sequences_none():
 
 
 def test_resolve_stop_sequences_limits_to_four():
-    """resolve_stop_sequences should process at most 4 sequences."""
-    call_count = [0]
-
-    def fake_encode(s, add_special_tokens=False):
-        call_count[0] += 1
-        return [call_count[0]]
-
-    fake_processor = SimpleNamespace(
-        tokenizer=SimpleNamespace(encode=fake_encode),
-    )
+    """resolve_stop_sequences should truncate to at most 4 sequences."""
     result = server.resolve_stop_sequences(["a", "b", "c", "d", "e", "f"])
     assert len(result) == 4

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -172,8 +172,7 @@ def test_chat_completions_stop_string_passed_as_eos_tokens(client):
         )
     assert resp.status_code == 200
     assert "eos_tokens" in mock_gen.call_args.kwargs
-    assert isinstance(mock_gen.call_args.kwargs["eos_tokens"], set)
-    assert 42 in mock_gen.call_args.kwargs["eos_tokens"]
+    assert mock_gen.call_args.kwargs["eos_tokens"] == ["\n\n", "</s>"]
 
 
 def test_chat_completions_no_stop_no_eos_tokens(client):
@@ -235,22 +234,22 @@ def test_responses_stop_string_passed_as_eos_tokens(client):
         )
     assert resp.status_code == 200
     assert "eos_tokens" in mock_gen.call_args.kwargs
-    assert 99 in mock_gen.call_args.kwargs["eos_tokens"]
+    assert mock_gen.call_args.kwargs["eos_tokens"] == ["STOP"]
 
 
-def test_resolve_stop_tokens_single_string():
-    """resolve_stop_tokens should handle a single string."""
+def test_resolve_stop_sequences_single_string():
+    """resolve_stop_sequences should handle a single string."""
     fake_processor = SimpleNamespace(
         tokenizer=SimpleNamespace(
             encode=lambda s, add_special_tokens=False: [10, 20],
         ),
     )
-    result = server.resolve_stop_tokens("hello", fake_processor)
-    assert result == {20}  # Last token of encoded string
+    result = server.resolve_stop_sequences("hello")
+    assert result == ["hello"]
 
 
-def test_resolve_stop_tokens_list():
-    """resolve_stop_tokens should handle a list of strings."""
+def test_resolve_stop_sequences_list():
+    """resolve_stop_sequences should handle a list of strings."""
     call_count = [0]
     token_map = {0: [10], 1: [20, 30]}
 
@@ -262,18 +261,17 @@ def test_resolve_stop_tokens_list():
     fake_processor = SimpleNamespace(
         tokenizer=SimpleNamespace(encode=fake_encode),
     )
-    result = server.resolve_stop_tokens(["a", "b"], fake_processor)
-    assert 10 in result
-    assert 30 in result
+    result = server.resolve_stop_sequences(["a", "b"])
+    assert result == ["a", "b"]
 
 
-def test_resolve_stop_tokens_none():
-    """resolve_stop_tokens should return None for None input."""
-    assert server.resolve_stop_tokens(None, None) is None
+def test_resolve_stop_sequences_none():
+    """resolve_stop_sequences should return None for None input."""
+    assert server.resolve_stop_sequences(None) is None
 
 
-def test_resolve_stop_tokens_limits_to_four():
-    """resolve_stop_tokens should process at most 4 sequences."""
+def test_resolve_stop_sequences_limits_to_four():
+    """resolve_stop_sequences should process at most 4 sequences."""
     call_count = [0]
 
     def fake_encode(s, add_special_tokens=False):
@@ -283,5 +281,5 @@ def test_resolve_stop_tokens_limits_to_four():
     fake_processor = SimpleNamespace(
         tokenizer=SimpleNamespace(encode=fake_encode),
     )
-    result = server.resolve_stop_tokens(["a", "b", "c", "d", "e", "f"], fake_processor)
-    assert len(result) == 4  # Only first 4 processed
+    result = server.resolve_stop_sequences(["a", "b", "c", "d", "e", "f"])
+    assert len(result) == 4


### PR DESCRIPTION
## Summary\nAccept stop parameter (string or list of up to 4 strings) in both endpoints. Passed as eos_tokens strings. 7 tests.