### PR TITLE
feat: add --max-context-tokens for OOM prevention

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -49,6 +49,25 @@ def get_prefill_step_size():
     return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
 
 
+def get_max_context_tokens() -> int:
+    """Maximum prompt tokens before rejecting a request. 0 = no limit."""
+    return int(os.environ.get("MAX_CONTEXT_TOKENS", 0))
+
+
+def check_context_length(prompt: str, processor, max_context: int) -> None:
+    """Raise HTTP 400 if the tokenized prompt exceeds *max_context* tokens."""
+    if max_context <= 0:
+        return
+    tokenizer = processor.tokenizer if hasattr(processor, "tokenizer") else processor
+    token_count = len(tokenizer.encode(prompt, add_special_tokens=False))
+    if token_count > max_context:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Prompt length ({token_count} tokens) exceeds maximum context "
+            f"window ({max_context} tokens).",
+        )
+
+
 def get_quantized_kv_bits(model: str):
     kv_bits = float(os.environ.get("KV_BITS", 0))
     if kv_bits == 0:
@@ -845,6 +864,7 @@ async def responses_endpoint(openai_request: OpenAIRequest):
             num_images=len(images),
             **template_kwargs,
         )
+        check_context_length(formatted_prompt, processor, get_max_context_tokens())
         generation_kwargs = build_generation_kwargs(openai_request, template_kwargs)
 
         generated_at = datetime.now().timestamp()
@@ -1113,6 +1133,7 @@ async def chat_completions_endpoint(request: ChatRequest):
             tools=tools,
             **template_kwargs,
         )
+        check_context_length(formatted_prompt, processor, get_max_context_tokens())
         generation_kwargs = build_generation_kwargs(request, template_kwargs)
 
         if request.stream:
@@ -1434,6 +1455,12 @@ def main():
         help="Start index (of token) for the quantized KV cache.",
     )
     parser.add_argument(
+        "--max-context-tokens",
+        type=int,
+        default=0,
+        help="Maximum context window in tokens. 0 = no limit. (default: %(default)s)",
+    )
+    parser.add_argument(
         "--reload",
         action="store_true",
         default=False,
@@ -1454,6 +1481,7 @@ def main():
     os.environ["KV_QUANT_SCHEME"] = args.kv_quant_scheme
     os.environ["MAX_KV_SIZE"] = str(args.max_kv_size)
     os.environ["QUANTIZED_KV_START"] = str(args.quantized_kv_start)
+    os.environ["MAX_CONTEXT_TOKENS"] = str(args.max_context_tokens)
 
     uvicorn.run(
         "mlx_vlm.server:app",

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -51,7 +51,10 @@ def get_prefill_step_size():
 
 def get_max_context_tokens() -> int:
     """Maximum prompt tokens before rejecting a request. 0 = no limit."""
-    return int(os.environ.get("MAX_CONTEXT_TOKENS", 0))
+    value = int(os.environ.get("MAX_CONTEXT_TOKENS", 0))
+    if value < 0:
+        raise ValueError(f"MAX_CONTEXT_TOKENS must be >= 0, got {value}")
+    return value
 
 
 def check_context_length(prompt: str, processor, max_context: int) -> None:
@@ -1481,6 +1484,8 @@ def main():
     os.environ["KV_QUANT_SCHEME"] = args.kv_quant_scheme
     os.environ["MAX_KV_SIZE"] = str(args.max_kv_size)
     os.environ["QUANTIZED_KV_START"] = str(args.quantized_kv_start)
+    if args.max_context_tokens < 0:
+        parser.error("--max-context-tokens must be >= 0")
     os.environ["MAX_CONTEXT_TOKENS"] = str(args.max_context_tokens)
 
     uvicorn.run(

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -130,3 +130,42 @@ def test_chat_completions_endpoint_forwards_explicit_sampling_args(client):
     assert mock_generate.call_args.kwargs["repetition_penalty"] == 1.15
     assert mock_generate.call_args.kwargs["logit_bias"] == {12: -1.5}
     assert mock_generate.call_args.kwargs["resize_shape"] == (512, 512)
+
+
+# ---------------------------------------------------------------------------
+# Context tracking tests
+# ---------------------------------------------------------------------------
+
+
+def test_check_context_length_within_limit():
+    fake_proc = SimpleNamespace(
+        tokenizer=SimpleNamespace(encode=lambda s, add_special_tokens=False: list(range(10))),
+    )
+    server.check_context_length("short", fake_proc, 100)
+
+
+def test_check_context_length_exceeds_limit():
+    from fastapi import HTTPException as _Exc
+    fake_proc = SimpleNamespace(
+        tokenizer=SimpleNamespace(encode=lambda s, add_special_tokens=False: list(range(200))),
+    )
+    with pytest.raises(_Exc) as exc_info:
+        server.check_context_length("long", fake_proc, 100)
+    assert exc_info.value.status_code == 400
+
+
+def test_check_context_length_zero_unlimited():
+    server.check_context_length("anything", None, 0)
+
+
+def test_get_max_context_tokens_default():
+    import os
+    os.environ.pop("MAX_CONTEXT_TOKENS", None)
+    assert server.get_max_context_tokens() == 0
+
+
+def test_get_max_context_tokens_from_env():
+    import os
+    os.environ["MAX_CONTEXT_TOKENS"] = "16384"
+    assert server.get_max_context_tokens() == 16384
+    os.environ.pop("MAX_CONTEXT_TOKENS")

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -158,14 +158,17 @@ def test_check_context_length_zero_unlimited():
     server.check_context_length("anything", None, 0)
 
 
-def test_get_max_context_tokens_default():
-    import os
-    os.environ.pop("MAX_CONTEXT_TOKENS", None)
+def test_get_max_context_tokens_default(monkeypatch):
+    monkeypatch.delenv("MAX_CONTEXT_TOKENS", raising=False)
     assert server.get_max_context_tokens() == 0
 
 
-def test_get_max_context_tokens_from_env():
-    import os
-    os.environ["MAX_CONTEXT_TOKENS"] = "16384"
+def test_get_max_context_tokens_from_env(monkeypatch):
+    monkeypatch.setenv("MAX_CONTEXT_TOKENS", "16384")
     assert server.get_max_context_tokens() == 16384
-    os.environ.pop("MAX_CONTEXT_TOKENS")
+
+
+def test_get_max_context_tokens_rejects_negative(monkeypatch):
+    monkeypatch.setenv("MAX_CONTEXT_TOKENS", "-1")
+    with pytest.raises(ValueError, match="must be >= 0"):
+        server.get_max_context_tokens()


### PR DESCRIPTION
## Summary\nReject requests exceeding context window with 400 instead of OOM crash. --max-context-tokens flag. 5 tests.