### PR TITLE
Add reusable LRU response store for replay state

### DIFF
--- a/mlx_vlm/responses_store.py
+++ b/mlx_vlm/responses_store.py
@@ -1,0 +1,131 @@
+"""Standalone in-memory LRU store for Responses API replay state."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from dataclasses import dataclass
+import threading
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class StoredResponse:
+    """Snapshot of a response's input and output items."""
+
+    input_items: Any
+    output_items: list[Any]
+
+
+class ResponseStore:
+    """Bounded thread-safe LRU store keyed by response id."""
+
+    def __init__(self, maxsize: int = 256):
+        if maxsize < 1:
+            raise ValueError("maxsize must be at least 1")
+
+        self._store: OrderedDict[str, StoredResponse] = OrderedDict()
+        self._maxsize = maxsize
+        self._lock = threading.Lock()
+
+    def save(
+        self,
+        response_id: str,
+        input_items: Any,
+        response_output: list[Any],
+    ) -> None:
+        """Store a replayable snapshot for a response id."""
+        entry = StoredResponse(
+            input_items=deepcopy(input_items),
+            output_items=deepcopy(response_output),
+        )
+
+        with self._lock:
+            if response_id in self._store:
+                self._store.move_to_end(response_id)
+            self._store[response_id] = entry
+            while len(self._store) > self._maxsize:
+                self._store.popitem(last=False)
+
+    def get(self, response_id: str) -> StoredResponse | None:
+        """Return a stored snapshot and mark it as recently used."""
+        with self._lock:
+            entry = self._store.get(response_id)
+            if entry is None:
+                return None
+            self._store.move_to_end(response_id)
+            return deepcopy(entry)
+
+    def replay_input(self, response_id: str) -> list[dict[str, Any]] | None:
+        """Rebuild prior request state as input items for future replay."""
+        entry = self.get(response_id)
+        if entry is None:
+            return None
+
+        items: list[dict[str, Any]] = []
+        original_input = entry.input_items
+
+        if isinstance(original_input, str):
+            items.append({"role": "user", "content": original_input})
+        elif isinstance(original_input, list):
+            items.extend(deepcopy(original_input))
+
+        for output_item in entry.output_items:
+            output_dict = _maybe_mapping(output_item)
+            if output_dict is None:
+                continue
+
+            item_type = output_dict.get("type", "")
+            if item_type == "message":
+                content = output_dict.get("content", [])
+                output_text_parts = []
+                for part in content:
+                    part_dict = _maybe_mapping(part)
+                    if part_dict is None:
+                        continue
+                    if part_dict.get("type") == "output_text":
+                        output_text_parts.append(
+                            {
+                                "type": "output_text",
+                                "text": part_dict.get("text", ""),
+                            }
+                        )
+
+                if output_text_parts:
+                    items.append(
+                        {
+                            "role": output_dict.get("role", "assistant"),
+                            "content": output_text_parts,
+                        }
+                    )
+            elif item_type == "function_call":
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": output_dict.get("call_id", ""),
+                        "name": output_dict.get("name", ""),
+                        "arguments": output_dict.get("arguments", ""),
+                    }
+                )
+
+        return items
+
+    def clear(self) -> None:
+        """Remove all stored entries."""
+        with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+
+def _maybe_mapping(value: Any) -> Mapping[str, Any] | None:
+    """Normalize dict-like or model-like objects into mappings."""
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    return None

--- a/mlx_vlm/tests/test_responses_store.py
+++ b/mlx_vlm/tests/test_responses_store.py
@@ -1,0 +1,211 @@
+"""Pure unit tests for the standalone response store module."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def _load_module(name: str, filename: str):
+    """Load a sibling module without importing mlx_vlm.__init__."""
+    module_path = Path(__file__).parent.parent / filename
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+responses_store = _load_module("responses_store", "responses_store.py")
+ResponseStore = responses_store.ResponseStore
+StoredResponse = responses_store.StoredResponse
+
+
+class DumpableItem:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self):
+        return self._payload
+
+
+def test_store_rejects_invalid_maxsize():
+    with pytest.raises(ValueError, match="maxsize"):
+        ResponseStore(maxsize=0)
+
+
+def test_store_save_and_get_round_trip():
+    store = ResponseStore()
+    store.save("resp_1", "hello", [{"type": "message"}])
+
+    entry = store.get("resp_1")
+
+    assert entry == StoredResponse(
+        input_items="hello",
+        output_items=[{"type": "message"}],
+    )
+
+
+def test_store_returns_snapshots_not_live_references():
+    input_items = [{"role": "user", "content": "hello"}]
+    output_items = [{"type": "function_call", "name": "lookup", "arguments": "{}"}]
+
+    store = ResponseStore()
+    store.save("resp_1", input_items, output_items)
+
+    input_items[0]["content"] = "mutated"
+    output_items[0]["name"] = "changed"
+
+    entry = store.get("resp_1")
+    assert entry is not None
+    assert entry.input_items[0]["content"] == "hello"
+    assert entry.output_items[0]["name"] == "lookup"
+
+    entry.output_items[0]["name"] = "client-change"
+    assert store.get("resp_1").output_items[0]["name"] == "lookup"
+
+
+def test_store_get_missing_returns_none():
+    store = ResponseStore()
+    assert store.get("resp_missing") is None
+
+
+def test_store_lru_eviction_respects_recent_reads():
+    store = ResponseStore(maxsize=2)
+    store.save("resp_a", "a", [])
+    store.save("resp_b", "b", [])
+
+    assert store.get("resp_a") is not None
+
+    store.save("resp_c", "c", [])
+
+    assert store.get("resp_a") is not None
+    assert store.get("resp_b") is None
+    assert store.get("resp_c") is not None
+
+
+def test_store_overwrite_does_not_grow_store():
+    store = ResponseStore(maxsize=2)
+    store.save("resp_1", "a", [])
+    store.save("resp_1", "b", [{"type": "message"}])
+
+    assert len(store) == 1
+    assert store.get("resp_1") == StoredResponse(
+        input_items="b",
+        output_items=[{"type": "message"}],
+    )
+
+
+def test_replay_input_rehydrates_string_input_and_output_text():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "hello",
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "Hello"},
+                    {"type": "ignored", "text": "skip"},
+                    {"type": "output_text", "text": " world"},
+                ],
+            }
+        ],
+    )
+
+    replay_items = store.replay_input("resp_1")
+
+    assert replay_items == [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "Hello"},
+                {"type": "output_text", "text": " world"},
+            ],
+        },
+    ]
+
+
+def test_replay_input_preserves_message_list_input():
+    original = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    store = ResponseStore()
+    store.save("resp_1", original, [])
+
+    replay_items = store.replay_input("resp_1")
+
+    assert replay_items == original
+    replay_items[0]["content"] = "changed"
+    assert store.get("resp_1").input_items[0]["content"] == "You are helpful."
+
+
+def test_replay_input_includes_function_calls():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "hello",
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "get_weather",
+                "arguments": '{"city":"NYC"}',
+            }
+        ],
+    )
+
+    replay_items = store.replay_input("resp_1")
+
+    assert replay_items == [
+        {"role": "user", "content": "hello"},
+        {
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "get_weather",
+            "arguments": '{"city":"NYC"}',
+        },
+    ]
+
+
+def test_replay_input_accepts_model_dump_items():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "hello",
+        [
+            DumpableItem(
+                {
+                    "type": "message",
+                    "content": [DumpableItem({"type": "output_text", "text": "Hi"})],
+                }
+            )
+        ],
+    )
+
+    assert store.replay_input("resp_1") == [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hi"}],
+        },
+    ]
+
+
+def test_store_clear_resets_entries():
+    store = ResponseStore()
+    store.save("resp_1", "a", [])
+    store.save("resp_2", "b", [])
+
+    store.clear()
+
+    assert len(store) == 0
+    assert store.get("resp_1") is None
+    assert store.replay_input("resp_2") is None


### PR DESCRIPTION
## Summary
- add a standalone in-memory LRU response store for Responses replay state
- preserve replayable input/output snapshots without importing the server stack
- add pure unit tests for save/get/eviction/replay behavior

## Notes
- draft fork PR for discussion and future reuse in previous_response_id work
- intentionally does not wire the store into `/responses` yet