### PR TITLE
Support previous_response_id replay for /responses

### DIFF
--- a/mlx_vlm/responses_replay.py
+++ b/mlx_vlm/responses_replay.py
@@ -1,0 +1,145 @@
+"""Helpers for expanding and parsing Responses API replay context."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .responses_store import ResponseStore
+
+
+def resolve_responses_input_items(
+    input_items: str | list[Any],
+    previous_response_id: str | None = None,
+    response_store: ResponseStore | None = None,
+) -> str | list[Any]:
+    """Expand ``previous_response_id`` into replayable response input items."""
+    if previous_response_id is None:
+        return deepcopy(input_items)
+
+    if response_store is None:
+        raise ValueError("response_store is required when previous_response_id is set.")
+
+    replayed = response_store.replay_input(previous_response_id)
+    if replayed is None:
+        raise LookupError(previous_response_id)
+
+    if isinstance(input_items, str):
+        current_items: list[Any] = [{"role": "user", "content": input_items}]
+    elif isinstance(input_items, list):
+        current_items = deepcopy(input_items)
+    else:
+        raise ValueError("Invalid input format.")
+
+    return replayed + current_items
+
+
+def responses_input_to_messages(
+    input_items: str | list[Any],
+) -> tuple[list[dict[str, Any]], list[str], str | None]:
+    """Convert Responses API input items into server chat messages and images."""
+    if isinstance(input_items, str):
+        return [{"role": "user", "content": input_items}], [], None
+    if not isinstance(input_items, list):
+        raise ValueError("Invalid input format.")
+
+    chat_messages: list[dict[str, Any]] = []
+    images: list[str] = []
+    instructions: str | None = None
+
+    for message in input_items:
+        message_dict = _as_mapping(message)
+        if message_dict is None:
+            raise ValueError("Invalid input format.")
+
+        item_type = message_dict.get("type", "")
+        if item_type == "function_call_output":
+            chat_messages.append(
+                {
+                    "role": "tool",
+                    "content": message_dict.get("output", ""),
+                    "tool_call_id": message_dict.get("call_id", "unknown"),
+                }
+            )
+            continue
+
+        if item_type == "function_call":
+            chat_messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": message_dict.get("call_id", ""),
+                            "type": "function",
+                            "function": {
+                                "name": message_dict.get("name", ""),
+                                "arguments": message_dict.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+            continue
+
+        role = message_dict.get("role")
+        if role is None:
+            raise ValueError("Invalid input format.")
+
+        text_content, new_images = _extract_content(role, message_dict.get("content"))
+        chat_message: dict[str, Any] = {"role": role, "content": text_content}
+
+        if message_dict.get("tool_calls") is not None:
+            chat_message["tool_calls"] = deepcopy(message_dict["tool_calls"])
+        if message_dict.get("tool_call_id") is not None:
+            chat_message["tool_call_id"] = message_dict["tool_call_id"]
+        if message_dict.get("name") is not None:
+            chat_message["name"] = message_dict["name"]
+
+        chat_messages.append(chat_message)
+        images.extend(new_images)
+
+        if role in {"system", "developer"} and text_content:
+            instructions = text_content
+
+    return chat_messages, images, instructions
+
+
+def _extract_content(role: str, content: Any) -> tuple[str | None, list[str]]:
+    if content is None or isinstance(content, str):
+        return content, []
+    if not isinstance(content, list):
+        raise ValueError("Invalid input format.")
+
+    text_parts: list[str] = []
+    images: list[str] = []
+    for item in content:
+        item_dict = _as_mapping(item)
+        if item_dict is None:
+            raise ValueError("Missing type in input item.")
+
+        item_type = item_dict.get("type", "")
+        if item_type in {"input_text", "text", "output_text"}:
+            text_parts.append(item_dict.get("text", ""))
+        elif role == "user" and item_type == "input_image":
+            images.append(item_dict.get("image_url", ""))
+        elif role == "user" and item_type == "image_url":
+            image_url = item_dict.get("image_url", {})
+            if isinstance(image_url, Mapping):
+                images.append(image_url.get("url", ""))
+            else:
+                raise ValueError("Invalid input item type.")
+        else:
+            raise ValueError("Invalid input item type.")
+
+    return "".join(text_parts), images
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    return None

--- a/mlx_vlm/responses_store.py
+++ b/mlx_vlm/responses_store.py
@@ -1,0 +1,131 @@
+"""Standalone in-memory LRU store for Responses API replay state."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from dataclasses import dataclass
+import threading
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class StoredResponse:
+    """Snapshot of a response's input and output items."""
+
+    input_items: Any
+    output_items: list[Any]
+
+
+class ResponseStore:
+    """Bounded thread-safe LRU store keyed by response id."""
+
+    def __init__(self, maxsize: int = 256):
+        if maxsize < 1:
+            raise ValueError("maxsize must be at least 1")
+
+        self._store: OrderedDict[str, StoredResponse] = OrderedDict()
+        self._maxsize = maxsize
+        self._lock = threading.Lock()
+
+    def save(
+        self,
+        response_id: str,
+        input_items: Any,
+        response_output: list[Any],
+    ) -> None:
+        """Store a replayable snapshot for a response id."""
+        entry = StoredResponse(
+            input_items=deepcopy(input_items),
+            output_items=deepcopy(response_output),
+        )
+
+        with self._lock:
+            if response_id in self._store:
+                self._store.move_to_end(response_id)
+            self._store[response_id] = entry
+            while len(self._store) > self._maxsize:
+                self._store.popitem(last=False)
+
+    def get(self, response_id: str) -> StoredResponse | None:
+        """Return a stored snapshot and mark it as recently used."""
+        with self._lock:
+            entry = self._store.get(response_id)
+            if entry is None:
+                return None
+            self._store.move_to_end(response_id)
+            return deepcopy(entry)
+
+    def replay_input(self, response_id: str) -> list[dict[str, Any]] | None:
+        """Rebuild prior request state as input items for future replay."""
+        entry = self.get(response_id)
+        if entry is None:
+            return None
+
+        items: list[dict[str, Any]] = []
+        original_input = entry.input_items
+
+        if isinstance(original_input, str):
+            items.append({"role": "user", "content": original_input})
+        elif isinstance(original_input, list):
+            items.extend(deepcopy(original_input))
+
+        for output_item in entry.output_items:
+            output_dict = _maybe_mapping(output_item)
+            if output_dict is None:
+                continue
+
+            item_type = output_dict.get("type", "")
+            if item_type == "message":
+                content = output_dict.get("content", [])
+                output_text_parts = []
+                for part in content:
+                    part_dict = _maybe_mapping(part)
+                    if part_dict is None:
+                        continue
+                    if part_dict.get("type") == "output_text":
+                        output_text_parts.append(
+                            {
+                                "type": "output_text",
+                                "text": part_dict.get("text", ""),
+                            }
+                        )
+
+                if output_text_parts:
+                    items.append(
+                        {
+                            "role": output_dict.get("role", "assistant"),
+                            "content": output_text_parts,
+                        }
+                    )
+            elif item_type == "function_call":
+                items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": output_dict.get("call_id", ""),
+                        "name": output_dict.get("name", ""),
+                        "arguments": output_dict.get("arguments", ""),
+                    }
+                )
+
+        return items
+
+    def clear(self) -> None:
+        """Remove all stored entries."""
+        with self._lock:
+            self._store.clear()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+
+def _maybe_mapping(value: Any) -> Mapping[str, Any] | None:
+    """Normalize dict-like or model-like objects into mappings."""
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict"):
+        return value.dict()
+    return None

--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -45,6 +45,11 @@ from .generate import (
     stream_generate,
 )
 from .prompt_utils import apply_chat_template
+from .responses_replay import (
+    resolve_responses_input_items,
+    responses_input_to_messages,
+)
+from .responses_store import ResponseStore
 from .sample_utils import top_p_sampling
 from .tool_parsers import _infer_tool_parser, load_tool_module
 from .utils import load, prepare_inputs
@@ -53,6 +58,7 @@ from .vision_cache import VisionFeatureCache
 
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
+_responses_store = ResponseStore()
 
 
 def get_prefill_step_size():
@@ -1196,6 +1202,9 @@ class OpenAIRequest(FlexibleBaseModel):
     thinking_start_token: Optional[str] = Field(
         None, description="Thinking start token."
     )
+    previous_response_id: Optional[str] = Field(
+        None, description="Replay context from a previous response."
+    )
     stream: bool = Field(
         False, description="Whether to stream the response chunk by chunk."
     )
@@ -1568,73 +1577,26 @@ async def responses_endpoint(request: Request):
         model, processor, config = get_cached_model(openai_request.model)
 
         kwargs = {}
-
-        chat_messages = []
-        images = []
-        instructions = None
-        if openai_request.input:
-            if isinstance(openai_request.input, str):
-                # If input is a string, treat it as a single text message
-                chat_messages.append({"role": "user", "content": openai_request.input})
-            elif isinstance(openai_request.input, list):
-                # If input is a list, treat it as a series of chat messages
-                for message in openai_request.input:
-                    if isinstance(message, ChatMessage):
-                        if isinstance(message.content, str):
-                            chat_messages.append(
-                                {"role": message.role, "content": message.content}
-                            )
-                            if message.role == "system":
-                                instructions = message.content
-                        elif isinstance(message.content, list):
-                            # Handle list of content items
-                            for item in message.content:
-                                if isinstance(item, dict):
-                                    if item["type"] == "input_text":
-                                        chat_messages.append(
-                                            {
-                                                "role": message.role,
-                                                "content": item["text"],
-                                            }
-                                        )
-                                        if message.role == "system":
-                                            instructions = item["text"]
-                                    # examples for multiple images (https://platform.openai.com/docs/guides/images?api-mode=responses)
-                                    elif item["type"] == "input_image":
-                                        images.append(item["image_url"])
-                                    else:
-                                        print(
-                                            f"invalid input item type: {item['type']}"
-                                        )
-                                        raise HTTPException(
-                                            status_code=400,
-                                            detail="Invalid input item type.",
-                                        )
-                                else:
-                                    print(
-                                        f"Invalid message content item format: {item}"
-                                    )
-                                    raise HTTPException(
-                                        status_code=400,
-                                        detail="Missing type in input item.",
-                                    )
-                        else:
-                            print("Invalid message content format.")
-                            raise HTTPException(
-                                status_code=400, detail="Invalid input format."
-                            )
-                    else:
-                        print("not a ChatMessage")
-                        raise HTTPException(
-                            status_code=400, detail="Invalid input format."
-                        )
-            else:
-                print("neither string not list")
-                raise HTTPException(status_code=400, detail="Invalid input format.")
-
-        else:
+        if not openai_request.input:
             print("no input")
             raise HTTPException(status_code=400, detail="Missing input.")
+
+        try:
+            expanded_input = resolve_responses_input_items(
+                openai_request.input,
+                previous_response_id=openai_request.previous_response_id,
+                response_store=_responses_store,
+            )
+            chat_messages, images, instructions = responses_input_to_messages(
+                expanded_input
+            )
+        except LookupError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Previous response not found: {exc.args[0]}",
+            ) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
         gen_args = _build_gen_args(openai_request)
 
@@ -1796,6 +1758,9 @@ async def responses_endpoint(request: Request):
                             },
                         }
                     )
+                    _responses_store.save(
+                        response_id, expanded_input, completed_response.output
+                    )
                     yield f"event: response.completed\ndata: {ResponseCompletedEvent(type='response.completed', response=completed_response).model_dump_json()}\n\n"
 
                 except Exception as e:
@@ -1896,6 +1861,7 @@ async def responses_endpoint(request: Request):
                         "total_tokens": prompt_tokens + output_tokens,
                     },
                 )
+                _responses_store.save(response_id, expanded_input, response.output)
 
                 elapsed = time.perf_counter() - request_start
                 logger.debug(

--- a/mlx_vlm/tests/test_responses_replay.py
+++ b/mlx_vlm/tests/test_responses_replay.py
@@ -1,0 +1,191 @@
+"""Pure unit tests for Responses replay helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+def _ensure_package():
+    package = types.ModuleType("mlx_vlm")
+    package.__path__ = [str(Path(__file__).parent.parent)]
+    sys.modules.setdefault("mlx_vlm", package)
+
+
+def _load_module(name: str, filename: str):
+    """Load a sibling mlx_vlm module without importing mlx_vlm.__init__."""
+    _ensure_package()
+    module_name = f"mlx_vlm.{name}"
+    module_path = Path(__file__).parent.parent / filename
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+responses_store = _load_module("responses_store", "responses_store.py")
+responses_replay = _load_module("responses_replay", "responses_replay.py")
+
+ResponseStore = responses_store.ResponseStore
+
+
+def test_resolve_replay_uses_previous_response_context():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "Hello",
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Hi there"}],
+            }
+        ],
+    )
+
+    expanded = responses_replay.resolve_responses_input_items(
+        "Follow up",
+        previous_response_id="resp_1",
+        response_store=store,
+    )
+
+    assert expanded == [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hi there"}],
+        },
+        {"role": "user", "content": "Follow up"},
+    ]
+
+
+def test_resolve_replay_supports_chained_previous_response_ids():
+    store = ResponseStore()
+    first_input = "Hello"
+    first_output = [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hi there"}],
+        }
+    ]
+    store.save("resp_1", first_input, first_output)
+
+    second_expanded = responses_replay.resolve_responses_input_items(
+        "Follow up",
+        previous_response_id="resp_1",
+        response_store=store,
+    )
+    store.save(
+        "resp_2",
+        second_expanded,
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Second answer"}],
+            }
+        ],
+    )
+
+    third_expanded = responses_replay.resolve_responses_input_items(
+        "Third turn",
+        previous_response_id="resp_2",
+        response_store=store,
+    )
+
+    assert third_expanded == [
+        {"role": "user", "content": "Hello"},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hi there"}],
+        },
+        {"role": "user", "content": "Follow up"},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Second answer"}],
+        },
+        {"role": "user", "content": "Third turn"},
+    ]
+
+
+def test_resolve_replay_missing_previous_response_raises_lookup_error():
+    store = ResponseStore()
+
+    with pytest.raises(LookupError, match="resp_missing"):
+        responses_replay.resolve_responses_input_items(
+            "Hello",
+            previous_response_id="resp_missing",
+            response_store=store,
+        )
+
+
+def test_responses_input_to_messages_extracts_text_images_and_instructions():
+    chat_messages, images, instructions = responses_replay.responses_input_to_messages(
+        [
+            {"role": "system", "content": "Be brief."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Describe this"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "It is a cat."}],
+            },
+        ]
+    )
+
+    assert chat_messages == [
+        {"role": "system", "content": "Be brief."},
+        {"role": "user", "content": "Describe this"},
+        {"role": "assistant", "content": "It is a cat."},
+    ]
+    assert images == ["data:image/png;base64,abc"]
+    assert instructions == "Be brief."
+
+
+def test_responses_input_to_messages_converts_function_calls():
+    chat_messages, images, instructions = responses_replay.responses_input_to_messages(
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "lookup",
+                "arguments": '{"city":"NYC"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_123",
+                "output": "72F",
+            },
+        ]
+    )
+
+    assert chat_messages == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": '{"city":"NYC"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "content": "72F", "tool_call_id": "call_123"},
+    ]
+    assert images == []
+    assert instructions is None

--- a/mlx_vlm/tests/test_responses_store.py
+++ b/mlx_vlm/tests/test_responses_store.py
@@ -1,0 +1,211 @@
+"""Pure unit tests for the standalone response store module."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def _load_module(name: str, filename: str):
+    """Load a sibling module without importing mlx_vlm.__init__."""
+    module_path = Path(__file__).parent.parent / filename
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+responses_store = _load_module("responses_store", "responses_store.py")
+ResponseStore = responses_store.ResponseStore
+StoredResponse = responses_store.StoredResponse
+
+
+class DumpableItem:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def model_dump(self):
+        return self._payload
+
+
+def test_store_rejects_invalid_maxsize():
+    with pytest.raises(ValueError, match="maxsize"):
+        ResponseStore(maxsize=0)
+
+
+def test_store_save_and_get_round_trip():
+    store = ResponseStore()
+    store.save("resp_1", "hello", [{"type": "message"}])
+
+    entry = store.get("resp_1")
+
+    assert entry == StoredResponse(
+        input_items="hello",
+        output_items=[{"type": "message"}],
+    )
+
+
+def test_store_returns_snapshots_not_live_references():
+    input_items = [{"role": "user", "content": "hello"}]
+    output_items = [{"type": "function_call", "name": "lookup", "arguments": "{}"}]
+
+    store = ResponseStore()
+    store.save("resp_1", input_items, output_items)
+
+    input_items[0]["content"] = "mutated"
+    output_items[0]["name"] = "changed"
+
+    entry = store.get("resp_1")
+    assert entry is not None
+    assert entry.input_items[0]["content"] == "hello"
+    assert entry.output_items[0]["name"] == "lookup"
+
+    entry.output_items[0]["name"] = "client-change"
+    assert store.get("resp_1").output_items[0]["name"] == "lookup"
+
+
+def test_store_get_missing_returns_none():
+    store = ResponseStore()
+    assert store.get("resp_missing") is None
+
+
+def test_store_lru_eviction_respects_recent_reads():
+    store = ResponseStore(maxsize=2)
+    store.save("resp_a", "a", [])
+    store.save("resp_b", "b", [])
+
+    assert store.get("resp_a") is not None
+
+    store.save("resp_c", "c", [])
+
+    assert store.get("resp_a") is not None
+    assert store.get("resp_b") is None
+    assert store.get("resp_c") is not None
+
+
+def test_store_overwrite_does_not_grow_store():
+    store = ResponseStore(maxsize=2)
+    store.save("resp_1", "a", [])
+    store.save("resp_1", "b", [{"type": "message"}])
+
+    assert len(store) == 1
+    assert store.get("resp_1") == StoredResponse(
+        input_items="b",
+        output_items=[{"type": "message"}],
+    )
+
+
+def test_replay_input_rehydrates_string_input_and_output_text():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "hello",
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "Hello"},
+                    {"type": "ignored", "text": "skip"},
+                    {"type": "output_text", "text": " world"},
+                ],
+            }
+        ],
+    )
+
+    replay_items = store.replay_input("resp_1")
+
+    assert replay_items == [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "Hello"},
+                {"type": "output_text", "text": " world"},
+            ],
+        },
+    ]
+
+
+def test_replay_input_preserves_message_list_input():
+    original = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    store = ResponseStore()
+    store.save("resp_1", original, [])
+
+    replay_items = store.replay_input("resp_1")
+
+    assert replay_items == original
+    replay_items[0]["content"] = "changed"
+    assert store.get("resp_1").input_items[0]["content"] == "You are helpful."
+
+
+def test_replay_input_includes_function_calls():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "hello",
+        [
+            {
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "get_weather",
+                "arguments": '{"city":"NYC"}',
+            }
+        ],
+    )
+
+    replay_items = store.replay_input("resp_1")
+
+    assert replay_items == [
+        {"role": "user", "content": "hello"},
+        {
+            "type": "function_call",
+            "call_id": "call_123",
+            "name": "get_weather",
+            "arguments": '{"city":"NYC"}',
+        },
+    ]
+
+
+def test_replay_input_accepts_model_dump_items():
+    store = ResponseStore()
+    store.save(
+        "resp_1",
+        "hello",
+        [
+            DumpableItem(
+                {
+                    "type": "message",
+                    "content": [DumpableItem({"type": "output_text", "text": "Hi"})],
+                }
+            )
+        ],
+    )
+
+    assert store.replay_input("resp_1") == [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hi"}],
+        },
+    ]
+
+
+def test_store_clear_resets_entries():
+    store = ResponseStore()
+    store.save("resp_1", "a", [])
+    store.save("resp_2", "b", [])
+
+    store.clear()
+
+    assert len(store) == 0
+    assert store.get("resp_1") is None
+    assert store.replay_input("resp_2") is None


### PR DESCRIPTION
## Summary
- add replay expansion for `/responses` requests that reference `previous_response_id`
- persist completed response input/output snapshots in the in-memory response store
- add pure unit tests for replay chaining without importing the MLX server stack

## Notes
- draft fork PR while upstream issue Blaizzy/mlx-vlm#1046 is still under discussion
- keeps the change focused on replay support instead of reviving the older large Responses API stack