### PR TITLE
Fix token queue timeout during long prefills

### DIFF
--- a/mlx_vlm/server.py
+++ b/mlx_vlm/server.py
@@ -9,7 +9,8 @@ import time
 import traceback
 import uuid
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field as dataclass_field
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from datetime import datetime
 from queue import Empty as QueueEmpty
 from queue import Queue
@@ -54,6 +55,7 @@ from .vision_cache import VisionFeatureCache
 
 DEFAULT_SERVER_HOST = "0.0.0.0"
 DEFAULT_SERVER_PORT = 8080
+DEFAULT_TOKEN_QUEUE_TIMEOUT = 600.0
 
 
 def get_default_enable_thinking():
@@ -74,6 +76,21 @@ def get_max_batch_size():
 
 def get_prefill_step_size():
     return int(os.environ.get("PREFILL_STEP_SIZE", DEFAULT_PREFILL_STEP_SIZE))
+
+
+def get_token_queue_timeout():
+    raw_timeout = os.environ.get(
+        "MLX_VLM_TOKEN_QUEUE_TIMEOUT", os.environ.get("TOKEN_QUEUE_TIMEOUT", "")
+    )
+    if raw_timeout == "":
+        return DEFAULT_TOKEN_QUEUE_TIMEOUT
+    try:
+        timeout = float(raw_timeout)
+    except ValueError:
+        return DEFAULT_TOKEN_QUEUE_TIMEOUT
+    if timeout <= 0:
+        return None
+    return timeout
 
 
 def get_quantized_kv_bits(model: str):
@@ -400,9 +417,23 @@ class ResponseGenerator:
             # closes immediately after seeing finish_reason isn't treated
             # as a client abort.
             ended = False
+            queue_timeout = get_token_queue_timeout()
             try:
                 while True:
-                    item = rqueue.get(timeout=60.0)
+                    try:
+                        item = rqueue.get(timeout=queue_timeout)
+                    except QueueEmpty as exc:
+                        timeout_label = (
+                            "without a timeout"
+                            if queue_timeout is None
+                            else f"for {queue_timeout:g}s"
+                        )
+                        raise RuntimeError(
+                            "Timed out waiting "
+                            f"{timeout_label} for the next generated token. "
+                            "Increase MLX_VLM_TOKEN_QUEUE_TIMEOUT for long "
+                            "prefills or reduce the prompt size."
+                        ) from exc
                     if item is None:
                         ended = True
                         break
@@ -624,9 +655,7 @@ class ResponseGenerator:
                     if current_item_index is not None
                     else new_items
                 )
-                active_queue_ids = {
-                    id(info.get("rqueue")) for info in active.values()
-                }
+                active_queue_ids = {id(info.get("rqueue")) for info in active.values()}
                 self._fail_active_requests(active, e, "Generation failed")
                 self._notify_request_queues(
                     [

--- a/mlx_vlm/tests/test_server.py
+++ b/mlx_vlm/tests/test_server.py
@@ -145,6 +145,9 @@ class TestResponseGenerator:
         gen._last_generation_error = None
         gen._last_generation_error_at = 0.0
         gen._stop = False
+        gen.draft_model = None
+        gen.wait_until_ready = lambda: None
+        gen._cpu_preprocess = lambda prompt, images, audio: {"input_ids": [1, 2, 3]}
         return gen
 
     def test_generate_arguments_defaults(self):
@@ -167,6 +170,76 @@ class TestResponseGenerator:
 
         monkeypatch.setenv("MLX_VLM_MAX_BATCH_SIZE", "bad")
         assert server.get_max_batch_size() == 0
+
+    def test_token_queue_timeout_defaults_to_long_prefill_window(self, monkeypatch):
+        monkeypatch.delenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", raising=False)
+        monkeypatch.delenv("TOKEN_QUEUE_TIMEOUT", raising=False)
+
+        assert server.get_token_queue_timeout() == 600.0
+
+    def test_token_queue_timeout_accepts_namespaced_env(self, monkeypatch):
+        monkeypatch.setenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", "42.5")
+
+        assert server.get_token_queue_timeout() == 42.5
+
+    def test_token_queue_timeout_accepts_legacy_env_alias(self, monkeypatch):
+        monkeypatch.delenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", raising=False)
+        monkeypatch.setenv("TOKEN_QUEUE_TIMEOUT", "90")
+
+        assert server.get_token_queue_timeout() == 90.0
+
+    def test_token_queue_timeout_invalid_values_fall_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", "bad")
+
+        assert server.get_token_queue_timeout() == 600.0
+
+    def test_token_queue_timeout_can_disable_timeout(self, monkeypatch):
+        monkeypatch.setenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", "0")
+
+        assert server.get_token_queue_timeout() is None
+
+    def test_token_iterator_reports_timeout_and_cancels_request(self, monkeypatch):
+        gen = self._bare_generator()
+        cancelled = []
+
+        class Requests:
+            def put(self, item):
+                rqueue = item[0]
+                rqueue.put(SimpleNamespace(uid="req-1"))
+
+        gen.requests = Requests()
+        gen._cancel = cancelled.append
+        monkeypatch.setenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", "0.01")
+
+        _, token_iter = gen.generate("hello")
+
+        with pytest.raises(RuntimeError, match="Timed out waiting for 0.01s"):
+            next(token_iter)
+
+        assert cancelled == ["req-1"]
+
+    def test_token_iterator_yields_items_before_timeout(self, monkeypatch):
+        gen = self._bare_generator()
+        cancelled = []
+        token = SimpleNamespace(text="hi")
+
+        class Requests:
+            def put(self, item):
+                rqueue: Queue = item[0]
+                rqueue.put(SimpleNamespace(uid="req-1"))
+                rqueue.put(token)
+                rqueue.put(None)
+
+        gen.requests = Requests()
+        gen._cancel = cancelled.append
+        monkeypatch.setenv("MLX_VLM_TOKEN_QUEUE_TIMEOUT", "0.01")
+
+        _, token_iter = gen.generate("hello")
+
+        assert next(token_iter) is token
+        with pytest.raises(StopIteration):
+            next(token_iter)
+        assert cancelled == []
 
     def test_generate_arguments_to_generate_kwargs(self):
         processor = lambda tokens, logits: logits


### PR DESCRIPTION
## Summary
- port the upstream-clean token queue timeout fix onto fork main
- replace hardcoded 60s continuous-batching queue timeout with configurable `MLX_VLM_TOKEN_QUEUE_TIMEOUT` / `TOKEN_QUEUE_TIMEOUT` support
- default to 600s and raise a clear timeout error while cancelling the active request

Tracks upstream issue Blaizzy/mlx-vlm#1068 and upstream PR Blaizzy/mlx-vlm#1111.

## Tests
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py::TestResponseGenerator -q`
- `uv run --with pytest pytest mlx_vlm/tests/test_server.py -q`
- `uv run --with pre-commit pre-commit run --files mlx_vlm/server.py mlx_vlm/tests/test_server.py`
- `python3 -m compileall mlx_vlm/server.py mlx_vlm/tests/test_server.py`